### PR TITLE
Fixing typos, accents, and math mode

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -35,7 +35,7 @@
 \begin{minipage}[t]{0.5\textwidth}
   \begin{node}
     %
-    Tout les anneaux considéré dans ce Traité posséderon un
+    Tout les anneaux considéré dans ce Traité posséderont un
     \emph{élément unité}; tout le modules sur un tel anneau seront
     supposés \emph{unitaires}; le homomorphismes d'anneaux seront toujours
     supposés \emph{transformer l'élément unité en élément unité};

--- a/main.tex
+++ b/main.tex
@@ -12,7 +12,7 @@
 \addbibresource{refs.bib}
 
 
-\title{The \emph{Dieudonn\'e} \LaTeX{} package}
+\title{The \emph{Dieudonné} \LaTeX{} package}
 \author{Jonathan Sterling}
 
 
@@ -24,27 +24,27 @@
 
 \mainmatter
 \CounterZeroNext{chapter}
-\chapter{Pr\'eliminaires}
+\chapter{Préliminaires}
 
 \section{Anneaux de Fractions}
 
 \CounterZeroNext{subsection}
-\subsection{Anneaux et alg\`ebres}
+\subsection{Anneaux et algèbres}
 
 \vspace{-1em}
 \begin{minipage}[t]{0.5\textwidth}
   \begin{node}
     %
-    Tout les anneaux consid\'er\'e dans ce Trait\'e poss\'ederon un
-    \emph{\'el\'ement unit\'e}; tout le modules sur un tel anneau seront
-    suppos\'es \emph{unitaires}; le homomorphismes d'anneaux seront toujours
-    suppos\'es \emph{transformer l'\'el\'ement unit\'e en \'el\'ement unit\'e};
+    Tout les anneaux considéré dans ce Traité posséderon un
+    \emph{élément unité}; tout le modules sur un tel anneau seront
+    supposés \emph{unitaires}; le homomorphismes d'anneaux seront toujours
+    supposés \emph{transformer l'élément unité en élément unité};
     sauf mention expresse du contraire, un sous-anneau d'un anneau $A$ sera
-    suppos\'e \emph{contenir l'\'el\'ement unit\'e de $A$}. Nous consid\'ererons
+    supposé \emph{contenir l'élément unité de $A$}. Nous considérerons
     surtout des anneaux \emph{commutatifs}, et lorsque nou parlerons  d'anneau
-    san pr\'eciser, il sera sous-entendu qu'il s'agit d'un anneau commutatif. Si
-    $A$ est un anneau non n\'ecessairement commutatif, par $A$-module nous
-    entendron toujours un module \emph{\`a gauche}, sauf mention expresse du
+    san préciser, il sera sous-entendu qu'il s'agit d'un anneau commutatif. Si
+    $A$ est un anneau non nécessairement commutatif, par $A$-module nous
+    entendron toujours un module \emph{à gauche}, sauf mention expresse du
     contraire.
     %
   \end{node}
@@ -75,20 +75,20 @@
 \textcolor{gray}{[omitted]}
 
 \setcounter{subsection}{2}
-\subsection{Propri\'et\'es fonctorielles}
+\subsection{Propriétés fonctorielles}
 
 \begin{node}\label{node:foo}
   %
   Soient $M, N$ deux $A$-modules, $u$ un $A$-homomorphism $M\to N$. Si $S$ est
-  une partie multiplicative de $A$, on d\'efinit un $S^{-1}A$-homorphisme
-  $S^{-1}M\to S^{-1}N$, not\'e $S^{-1}u$, en posan $(S^{-1})(m/s) = u(m)/s$; si
-  $S^{-1}M$ et $S^{-1}N$ sont canoniquement identifi\'es \`a
+  une partie multiplicative de $A$, on définit un $S^{-1}A$-homorphisme
+  $S^{-1}M\to S^{-1}N$, noté $S^{-1}u$, en posan $(S^{-1})(m/s) = u(m)/s$; si
+  $S^{-1}M$ et $S^{-1}N$ sont canoniquement identifiés à
   $S^{-1}\otimes_{A}M$ et $S^{-1}\otimes_{A}N$ (1.2\textperiodcentered5),
-  $S^{-1}u$ est identifi\'e \`a $1\otimes u$. Se $I$ est un troisi\`eme
+  $S^{-1}u$ est identifié à $1\otimes u$. Se $I$ est un troisième
   $A$-module, $v$ un $A$-homomorphisme $N\to P$, on a $S^{-1}(v\circ u) =
   (S^{-1}v)\circ (S^{-1}u)$; autrement dit $S^{-1}M$ est on \emph{foncteur
-  covariant en $M$}, de le cat\'egorie des $A$-modules dans celle des
-  $S^{-1}A$-modules ($A$ et $S$ \'etant fix\'es).
+  covariant en $M$}, de le catégorie des $A$-modules dans celle des
+  $S^{-1}A$-modules ($A$ et $S$ étant fixés).
 \end{node}
 
 \begin{node}
@@ -96,14 +96,14 @@
   \begin{equation}
     M\xrightarrow{u} N\xrightarrow{v} P
   \end{equation}
-  est exacte, il en est de m\^eme de la suite
+  est exacte, il en est de même de la suite
   \begin{equation}
     S^{-1}M\xrightarrow{S^{-1}u}S^{-1}N\xrightarrow{S^-1v}S^{-1}P.
   \end{equation}
 
   En particulier, si $u:M\to N$ est injectif (resp.\ surjectif), il en est de
-  m\^eme de $S^{-1}u$; si $N$ et $P$ sont deux sou-modules de $M$, $S^{-1}N$ et
-  $S^{-1}P$ s'identifient canoniquement \`a des sous-modules de $S^{-1}$, et
+  même de $S^{-1}u$; si $N$ et $P$ sont deux sou-modules de $M$, $S^{-1}N$ et
+  $S^{-1}P$ s'identifient canoniquement à des sous-modules de $S^{-1}$, et
   l'on a
   \begin{equation}\label{eq:foo}
     S^{-1}(N+P) = S^{-1}N+S^{-1}P\quad\text{et}\quad S^{-1}(N\cap P) = (S^{-1}N)\cap(S^{-1}P).

--- a/main.tex
+++ b/main.tex
@@ -39,11 +39,11 @@
     \emph{élément unité}; tout le modules sur un tel anneau seront
     supposés \emph{unitaires}; le homomorphismes d'anneaux seront toujours
     supposés \emph{transformer l'élément unité en élément unité};
-    sauf mention expresse du contraire, un sous-anneau d'un anneau $A$ sera
-    supposé \emph{contenir l'élément unité de $A$}. Nous considérerons
+    sauf mention expresse du contraire, un sous-anneau d'un anneau \(A\) sera
+    supposé \emph{contenir l'élément unité de \(A\)}. Nous considérerons
     surtout des anneaux \emph{commutatifs}, et lorsque nou parlerons  d'anneau
     san préciser, il sera sous-entendu qu'il s'agit d'un anneau commutatif. Si
-    $A$ est un anneau non nécessairement commutatif, par $A$-module nous
+    \(A\) est un anneau non nécessairement commutatif, par \(A\)-module nous
     entendron toujours un module \emph{à gauche}, sauf mention expresse du
     contraire.
     %
@@ -58,11 +58,11 @@
     All the rings considered in this treatise possess a \emph{unit element};
     all the modules on such a ring are assumed to be unitary; the homomorphisms
     of rings will be assumed \emph{take the unit element to the unit element};
-    unless specifically mentioned to the countrary, a subring of a ring $A$
-    will be assumed to \emph{contain the unit element of $A$}. We consider
+    unless specifically mentioned to the countrary, a subring of a ring \(A\)
+    will be assumed to \emph{contain the unit element of \(A\)}. We consider
     mostly \emph{commutative} rings, and when we speak of a ring without
-    specifying, it will be implied that  it is a commutative ring. If $A$ is a
-    not necessarily commutative ring, by $A$-module we always mean a
+    specifying, it will be implied that  it is a commutative ring. If \(A\) is a
+    not necessarily commutative ring, by \(A\)-module we always mean a
     \emph{left} module, unless mentioned specifically to the contrary.
     %
   \end{node}
@@ -79,20 +79,20 @@
 
 \begin{node}\label{node:foo}
   %
-  Soient $M, N$ deux $A$-modules, $u$ un $A$-homomorphism $M\to N$. Si $S$ est
-  une partie multiplicative de $A$, on définit un $S^{-1}A$-homorphisme
-  $S^{-1}M\to S^{-1}N$, noté $S^{-1}u$, en posan $(S^{-1})(m/s) = u(m)/s$; si
-  $S^{-1}M$ et $S^{-1}N$ sont canoniquement identifiés à
-  $S^{-1}\otimes_{A}M$ et $S^{-1}\otimes_{A}N$ (1.2\textperiodcentered5),
-  $S^{-1}u$ est identifié à $1\otimes u$. Se $I$ est un troisième
-  $A$-module, $v$ un $A$-homomorphisme $N\to P$, on a $S^{-1}(v\circ u) =
-  (S^{-1}v)\circ (S^{-1}u)$; autrement dit $S^{-1}M$ est on \emph{foncteur
-  covariant en $M$}, de le catégorie des $A$-modules dans celle des
-  $S^{-1}A$-modules ($A$ et $S$ étant fixés).
+  Soient \(M, N\) deux \(A\)-modules, \(u\) un \(A\)-homomorphism \(M\to N\). Si \(S\) est
+  une partie multiplicative de \(A\), on définit un \(S^{-1}A\)-homorphisme
+  \(S^{-1}M\to S^{-1}N\), noté \(S^{-1}u\), en posan \((S^{-1})(m/s) = u(m)/s\); si
+  \(S^{-1}M\) et \(S^{-1}N\) sont canoniquement identifiés à
+  \(S^{-1}\otimes_{A}M\) et \(S^{-1}\otimes_{A}N\) (1.2\textperiodcentered5),
+  \(S^{-1}u\) est identifié à \(1\otimes u\). Se \(I\) est un troisième
+  \(A\)-module, \(v\) un \(A\)-homomorphisme \(N\to P\), on a \(S^{-1}(v\circ u) =
+  (S^{-1}v)\circ (S^{-1}u)\); autrement dit \(S^{-1}M\) est on \emph{foncteur
+  covariant en \(M\)}, de le catégorie des \(A\)-modules dans celle des
+  \(S^{-1}A\)-modules (\(A\) et \(S\) étant fixés).
 \end{node}
 
 \begin{node}
-  Le foncteur $S^{-1}M$ est \emph{exact}; autrement dit, si la suite
+  Le foncteur \(S^{-1}M\) est \emph{exact}; autrement dit, si la suite
   \begin{equation}
     M\xrightarrow{u} N\xrightarrow{v} P
   \end{equation}
@@ -101,9 +101,9 @@
     S^{-1}M\xrightarrow{S^{-1}u}S^{-1}N\xrightarrow{S^-1v}S^{-1}P.
   \end{equation}
 
-  En particulier, si $u:M\to N$ est injectif (resp.\ surjectif), il en est de
-  même de $S^{-1}u$; si $N$ et $P$ sont deux sou-modules de $M$, $S^{-1}N$ et
-  $S^{-1}P$ s'identifient canoniquement à des sous-modules de $S^{-1}$, et
+  En particulier, si \(u:M\to N\) est injectif (resp.\ surjectif), il en est de
+  même de \(S^{-1}u\); si \(N\) et \(P\) sont deux sou-modules de \(M\), \(S^{-1}N\) et
+  \(S^{-1}P\) s'identifient canoniquement à des sous-modules de \(S^{-1}\), et
   l'on a
   \begin{equation}\label{eq:foo}
     S^{-1}(N+P) = S^{-1}N+S^{-1}P\quad\text{et}\quad S^{-1}(N\cap P) = (S^{-1}N)\cap(S^{-1}P).

--- a/main.tex
+++ b/main.tex
@@ -41,10 +41,10 @@
     supposés \emph{transformer l'élément unité en élément unité};
     sauf mention expresse du contraire, un sous-anneau d'un anneau \(A\) sera
     supposé \emph{contenir l'élément unité de \(A\)}. Nous considérerons
-    surtout des anneaux \emph{commutatifs}, et lorsque nou parlerons  d'anneau
-    san préciser, il sera sous-entendu qu'il s'agit d'un anneau commutatif. Si
+    surtout des anneaux \emph{commutatifs}, et lorsque nous parlerons  d'anneau
+    sans préciser, il sera sous-entendu qu'il s'agit d'un anneau commutatif. Si
     \(A\) est un anneau non nécessairement commutatif, par \(A\)-module nous
-    entendron toujours un module \emph{à gauche}, sauf mention expresse du
+    entendrons toujours un module \emph{à gauche}, sauf mention expresse du
     contraire.
     %
   \end{node}
@@ -102,7 +102,7 @@
   \end{equation}
 
   En particulier, si \(u:M\to N\) est injectif (resp.\ surjectif), il en est de
-  même de \(S^{-1}u\); si \(N\) et \(P\) sont deux sou-modules de \(M\), \(S^{-1}N\) et
+  même de \(S^{-1}u\); si \(N\) et \(P\) sont deux sous-modules de \(M\), \(S^{-1}N\) et
   \(S^{-1}P\) s'identifient canoniquement à des sous-modules de \(S^{-1}\), et
   l'on a
   \begin{equation}\label{eq:foo}


### PR DESCRIPTION
This pull request tries to improve the original main.tex file along three axis:

- Use `\(…\)` instead of `$…$`, as [it is generally recommended](https://tex.stackexchange.com/q/510/34551)
- Use "native" accents (e.g. `é`) instead of commands (`\'e`),
- Fixed a couple of misprints in French (typically, missing "s").

I hope you will find it useful!